### PR TITLE
Ensure pyarrow still exists

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -6,6 +6,6 @@ USER root
 
 RUN R -e "install.packages(c('astsa'), repos = 'https://cloud.r-project.org/', Ncpus = parallel::detectCores())"
 
-RUN mamba install -yc conda-forge "gluonts[torch,mxnet,pro,R]" orjson
+RUN mamba install -yc conda-forge "gluonts[torch,mxnet,pro,R]" orjson pyarrow
 
 USER $NB_USER

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
                         sh 'podman run -it --rm --pull=never localhost/$IMAGE_NAME which rstudio'
                         sh 'podman run -it --rm --pull=never localhost/$IMAGE_NAME R -q -e "getRversion() >= \\"4.1.3\\"" | tee /dev/stderr | grep -q "TRUE"'
                         sh 'podman run -it --rm --pull=never localhost/$IMAGE_NAME R -e "library(\"astsa\")"'
-                        sh 'podman run -it --rm --pull=never localhost/$IMAGE_NAME python -c "import gluonts"'
+                        sh 'podman run -it --rm --pull=never localhost/$IMAGE_NAME python -c "import gluonts; import pyarrow"'
                         sh 'podman run -d --name=$IMAGE_NAME --rm --pull=never -p 8888:8888 localhost/$IMAGE_NAME start-notebook.sh --NotebookApp.token="jenkinstest"'
                         sh 'sleep 10 && curl -v http://localhost:8888/rstudio?token=jenkinstest 2>&1 | grep -P "HTTP\\S+\\s[1-3][0-9][0-9]\\s+[\\w\\s]+\\s*$"'
                         sh 'curl -v http://localhost:8888/lab?token=jenkinstest 2>&1 | grep -P "HTTP\\S+\\s200\\s+[\\w\\s]+\\s*$"'


### PR DESCRIPTION
The mamba output doesn't seem to indicate pyarrow was included, so that adds it explicitly and adds an import test for it since the current gluonts code in the repo itself clearly depends on it.  gluonts might import, but I'm not 100% confident it'll actually work without this.  pip brought it in in the previous install method.